### PR TITLE
feat: make the actual estimated time more visible

### DIFF
--- a/2.0-stop/index.html
+++ b/2.0-stop/index.html
@@ -1,3 +1,4 @@
+<link rel="stylesheet" href="../styles.css" />
 <script>
    const HEIGHT_2_1 = 713000;
    async function main() {

--- a/2.1/index.html
+++ b/2.1/index.html
@@ -1,3 +1,4 @@
+<link rel="stylesheet" href="../styles.css" />
 <script>
    const HEIGHT_2_1 = 781551;
    async function main() {

--- a/2.2/index.html
+++ b/2.2/index.html
@@ -1,3 +1,4 @@
+<link rel="stylesheet" href="../styles.css" />
 <script>
    const HEIGHT_2_2 = 787651;
    async function main() {

--- a/2.3/index.html
+++ b/2.3/index.html
@@ -1,3 +1,4 @@
+<link rel="stylesheet" href="../styles.css" />
 <script>
    const HEIGHT_2_3 = 788240;
    async function main() {

--- a/2.4/index.html
+++ b/2.4/index.html
@@ -1,3 +1,4 @@
+<link rel="stylesheet" href="../styles.css" />
 <script>
    const HEIGHT_2_4 = 791551;
    async function main() {

--- a/2.5/index.html
+++ b/2.5/index.html
@@ -1,3 +1,4 @@
+<link rel="stylesheet" href="../styles.css" />
 <script>
    const HEIGHT_2_5 = 840360;
    async function main() {

--- a/3.0/index.html
+++ b/3.0/index.html
@@ -1,3 +1,4 @@
+<link rel="stylesheet" href="../styles.css" />
 <script>
    const HEIGHT_3_0 = 867867;
    async function main() {

--- a/3.1/index.html
+++ b/3.1/index.html
@@ -1,3 +1,4 @@
+<link rel="stylesheet" href="../styles.css" />
 <script>
     const HEIGHT_3_1 = 875000;
     async function main() {

--- a/3.2/index.html
+++ b/3.2/index.html
@@ -5,6 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Wen 3.2 HardFork?</title>
+  <link rel="stylesheet" href="../styles.css" />
 
   <style>
     :root {
@@ -96,4 +97,3 @@
 </body>
 
 </html>
-

--- a/3.3/index.html
+++ b/3.3/index.html
@@ -5,6 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Wen 3.3 HardFork?</title>
+  <link rel="stylesheet" href="../styles.css" />
 
   <style>
     :root {
@@ -96,4 +97,3 @@
 </body>
 
 </html>
-

--- a/block.html
+++ b/block.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bitcoin Block Height Estimator</title>
+    <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
     <h1>Bitcoin Block Height Estimation</h1>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,7 @@
+#expected_date {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #1a4b8c;
+  display: inline-block;
+  margin-top: 0.5rem;
+}


### PR DESCRIPTION
Just trying to make the estimated date, the main purpose of the page, be more visually highlighted. As it is now, my eye is always drawn to the date/time at the bottom first.