### PR TITLE
fix: close bold tags in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,11 @@
           let next_cycle_start = (REWARD_CYCLE_LENGTH * (current_cycle + 1)) + START_HEIGHT;
           let next_cycle_prep_start = next_cycle_start - PREPARE_PHASE_LENGTH;
           let time_left = parseFloat(11 * (next_cycle_prep_start - height) / 60).toFixed(2);
-          document.getElementById("height").innerHTML = `<b>${height}<b>`;
-          document.getElementById("cycle_number").innerHTML = `<b>${current_cycle}<b>`;
-          document.getElementById("next_reward").innerHTML = `<b>${next_cycle_start}<b>`;
-          document.getElementById("next_prepare").innerHTML = `<b>${next_cycle_prep_start}<b>`;
-          document.getElementById("time_left").innerHTML = `<b>${time_left}<b>`;
+          document.getElementById("height").innerHTML = `<b>${height}</b>`;
+          document.getElementById("cycle_number").innerHTML = `<b>${current_cycle}</b>`;
+          document.getElementById("next_reward").innerHTML = `<b>${next_cycle_start}</b>`;
+          document.getElementById("next_prepare").innerHTML = `<b>${next_cycle_prep_start}</b>`;
+          document.getElementById("time_left").innerHTML = `<b>${time_left}</b>`;
 
        })
    }


### PR DESCRIPTION
## What
Fix unclosed `<b>` tags in index.html — was `<b>${value}<b>`, now correctly `<b>${value}</b>`.

## Why
Unclosed bold tags cause malformed HTML rendering.

## How to verify
- Open index.html in a browser; bold text displays correctly without cascading formatting issues.